### PR TITLE
Handle container metadata only for root containers

### DIFF
--- a/container_crawler/crawler.py
+++ b/container_crawler/crawler.py
@@ -200,7 +200,9 @@ class Crawler(object):
                     settings, per_account=per_account)
 
                 last_primary_row = handler.get_last_processed_row(broker_id)
-                handler.handle_container_metadata(broker.metadata, broker_id)
+                if broker.is_root_container():
+                    handler.handle_container_metadata(broker.metadata,
+                                                      broker_id)
                 primary_rows = self._get_new_rows(
                     broker, last_primary_row, nodes_count, node_id, False)
                 if primary_rows:

--- a/test/unit/test_container_crawler.py
+++ b/test/unit/test_container_crawler.py
@@ -430,6 +430,7 @@ class TestContainerCrawler(unittest.TestCase):
             (mock.call.is_deleted(),
              mock.call.is_sharded(),
              mock.call.get_info(),
+             mock.call.is_root_container(),
              mock.call.get_items_since(5000, 1000),
              mock.call.get_items_since(10, 1000))
             for _ in test_containers]
@@ -925,6 +926,8 @@ class TestContainerCrawler(unittest.TestCase):
 
         self.mock_broker.is_sharded.side_effect = [True, False, False, False,
                                                    False]
+        self.mock_broker.is_root_container.side_effect = [True, False, False,
+                                                          False, False]
         with self._patch_broker():
             self.crawler.run_once()
 
@@ -941,3 +944,4 @@ class TestContainerCrawler(unittest.TestCase):
             for sharded_cont in sharded_containers]
         self.assertEqual(expected_calls,
                          self.mock_handler_factory.instance.mock_calls)
+        self.mock_handler.handle_container_metadata.assert_called_once()


### PR DESCRIPTION
This patch adds a check to make sure the broker is a root container
before calling handle_container_metadata.