### PR TITLE
Log traceback on debug level only

### DIFF
--- a/container_crawler/crawler.py
+++ b/container_crawler/crawler.py
@@ -127,10 +127,11 @@ class Crawler(object):
         while 1:
             try:
                 work = self.work_queue.get()
-            except:
-                self.log(
-                    'error', 'Failed to fetch items from the queue: %s' %
-                    traceback.format_exc())
+            except Exception as e:
+                self.log('error', 'Failed to fetch items from the queue: %s' %
+                         str(e))
+                self.log('debug', 'Failed to fetch items from the queue: %s' %
+                         traceback.format_exc())
                 eventlet.sleep(100)
                 continue
 
@@ -144,9 +145,12 @@ class Crawler(object):
                 container_job.complete_task()
             except RetryError:
                 container_job.complete_task(retry=True)
-            except:
+            except Exception as e:
                 container_job.complete_task(error=True)
-                self.log('error', u'Failed to handle row %s (%s): %r' % (
+                self.log('error', u'Failed to handle row %s (%s): %s' % (
+                    row['ROWID'], row['name'].decode('utf-8'),
+                    str(e)))
+                self.log('debug', u'Failed to handle row %s (%s): %r' % (
                     row['ROWID'], row['name'].decode('utf-8'),
                     traceback.format_exc()))
             finally:

--- a/test/unit/test_container_crawler.py
+++ b/test/unit/test_container_crawler.py
@@ -279,13 +279,17 @@ class TestContainerCrawler(unittest.TestCase):
             self.crawler.run_once()
 
         self.assertEqual(
-            [mock.call("Failed to handle row %d (%s): 'traceback'" % (
+            [mock.call("Failed to handle row %d (%s): fail" % (
                        row['ROWID'], row['name'].decode('utf-8')))],
             self.crawler.logger.error.mock_calls)
+        self.assertEqual(
+            [mock.call("Failed to handle row %d (%s): 'traceback'" % (
+                       row['ROWID'], row['name'].decode('utf-8')))],
+            self.crawler.logger.debug.mock_calls)
 
     @mock.patch('container_crawler.crawler.traceback.format_exc')
     def test_worker_handles_all_exceptions(self, tb_mock):
-        self.mock_handler.handle.side_effect = BaseException('base error')
+        self.mock_handler.handle.side_effect = Exception('foo')
         tb_mock.return_value = 'traceback'
         self.crawler.logger = mock.Mock()
 
@@ -298,10 +302,14 @@ class TestContainerCrawler(unittest.TestCase):
         with self._patch_broker():
             self.crawler.run_once()
 
-        self.assertEqual([mock.call(
-            "Failed to handle row %d (%s): 'traceback'" % (
-                row['ROWID'], row['name'].decode('utf-8')))],
+        self.assertEqual(
+            [mock.call("Failed to handle row %d (%s): foo" % (
+                       row['ROWID'], row['name'].decode('utf-8')))],
             self.crawler.logger.error.mock_calls)
+        self.assertEqual(
+            [mock.call("Failed to handle row %d (%s): 'traceback'" % (
+                       row['ROWID'], row['name'].decode('utf-8')))],
+            self.crawler.logger.debug.mock_calls)
 
     @mock.patch('container_crawler.crawler.traceback.format_exc')
     def test_unicode_container_account_failure(self, tb_mock):


### PR DESCRIPTION
Changed a couple of log statements to log the exception message
only, and then log the traceback on debug level.